### PR TITLE
SMTPClient conformance to MailClientProtocol

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,12 @@ let package = Package(
                 "Mail"
             ]
         ),
+        Target(
+            name: "SMTPClient",
+            dependencies: [
+                "Mail"
+            ]
+        ),
     ],
     dependencies: [
         .Package(url: "https://github.com/vapor/vapor.git", majorVersion: 1, minor: 5),

--- a/README.md
+++ b/README.md
@@ -7,11 +7,9 @@ Vapor Provider for sending email through swappable backends.
 Backends included in this repository:
 
 * `SendGrid`, a fully-featured implementation of the SendGrid V3 Mail Send API.
+* `SMTPClient`, which conforms Vapor's built-in SMTP Client to this backend.
 * `InMemoryMailClient`, a development-only backend which stores emails in memory.
 * `ConsoleMailClient`, a development-only backend which outputs emails to the console.
-
-SMTP is not included. Use Vapor's built in SMTPClient if you need to use the
-SMTP protocol.
 
 ## 📘 Overview
 
@@ -96,6 +94,44 @@ if let sendgrid = try drop.mailer.make() as? SendGridClient {
 ```
 
 See `SendGridEmail.swift` for all configuration options.
+
+### SMTPClient
+
+First, set up the Provider. Note that the security layer and stream types are
+not loaded from config, and must be set in code.
+
+```Swift
+import Mail
+import SMTPClient
+
+let drop = try makeDroplet(config: config)
+SMTPClient<TCPClientStream>.setSecurityLayer(.tls(nil))
+try drop.addProvider(Mail.Provider<SMTPClient<TCPClientStream>>.self)
+```
+
+SMTPClient expects a configuration file named `smtp.json` with the following
+format, and will throw `.noSMTPConfig` or `.missingConfig(fieldname)` if
+configuration was not found.
+
+```json
+{
+    "host": "smtp.host.com",
+    "port": 465,
+    "username": "username",
+    "password": "password"
+}
+```
+
+Once installed, you can send emails using the following format:
+
+```Swift
+let email = Email(from: …, to: …, subject: …, body: …)
+try drop.mailer?.send(email)
+```
+
+All connections will use the host, port, username, password, stream type and
+security layer that you set with the Provider. If you need to customise any of
+these per-send, you should use Vapor's `SMTPClient` directly.
 
 ### Development backends
 

--- a/Sources/SMTPClient/SMTPClient+MailClientProtocol.swift
+++ b/Sources/SMTPClient/SMTPClient+MailClientProtocol.swift
@@ -1,0 +1,68 @@
+import HTTP
+import Mail
+import SMTP
+import Vapor
+import Foundation
+import Transport
+
+var _credentials: SMTPCredentials?
+var _host: String?
+var _port: Int?
+var _securityLayer: SecurityLayer?
+
+extension SMTPClient {
+
+    public static func setSecurityLayer(_ securityLayer: SecurityLayer) {
+        _securityLayer = securityLayer
+    }
+
+}
+
+extension SMTPClient: MailClientProtocol {
+
+  public static func configure(_ config: Settings.Config) throws {
+      guard let c = config["smtp"]?.object else {
+          throw SMTPMailClientError.noSMTPConfig
+      }
+      guard let username = c["username"]?.string else {
+          throw SMTPMailClientError.missingConfig("username")
+      }
+      guard let password = c["password"]?.string else {
+          throw SMTPMailClientError.missingConfig("password")
+      }
+      guard let host = c["host"]?.string else {
+          throw SMTPMailClientError.missingConfig("host")
+      }
+      guard let port = c["port"]?.int else {
+          throw SMTPMailClientError.missingConfig("port")
+      }
+      _credentials = SMTPCredentials(user: username, pass: password)
+      _host = host
+      _port = port
+  }
+
+  public static func boot(_ drop: Vapor.Droplet) {}
+
+  public convenience init() throws {
+      guard let host = _host else {
+          throw SMTPMailClientError.missingConfig("host")
+      }
+      guard let port = _port else {
+          throw SMTPMailClientError.missingConfig("port")
+      }
+      guard let securityLayer = _securityLayer else {
+          throw SMTPMailClientError.missingConfig("securityLayer")
+      }
+      try self.init(host: host, port: port, securityLayer: securityLayer)
+  }
+
+  public func send(_ emails: [SMTP.Email]) throws {
+      guard let credentials = _credentials else {
+          throw SMTPMailClientError.missingConfig("username/password")
+      }
+      try emails.forEach {
+          try send($0, using: credentials)
+      }
+  }
+
+}

--- a/Sources/SMTPClient/SMTPMailClientError.swift
+++ b/Sources/SMTPClient/SMTPMailClientError.swift
@@ -1,0 +1,16 @@
+/*
+    An error, either in configuration or in execution.
+*/
+public enum SMTPMailClientError: Swift.Error {
+
+    /*
+        No configuration for SMTP could be found at all.
+    */
+    case noSMTPConfig
+    /*
+        A required configuration key was missing. The associated value is the
+        name of the missing key.
+    */
+    case missingConfig(String)
+
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -4,6 +4,7 @@ import XCTest
 
 @testable import MailTests
 @testable import SendGridTests
+@testable import SMTPClientTests
 
 XCTMain([
     // MailClientProtocol Tests
@@ -17,6 +18,9 @@ XCTMain([
 
     // SendGridClient Tests
     testCase(SendGridClientTests.allTests),
+
+    // SMTPClient Tests
+    testCase(SMTPClientTests.allTests),
 ])
 
 #endif

--- a/Tests/SMTPClientTests/SMTPClientTests.swift
+++ b/Tests/SMTPClientTests/SMTPClientTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+import Mail
+import SMTP
+import SMTPClient
+@testable import Vapor
+import Transport
+
+// Test inbox: https://www.mailinator.com/inbox2.jsp?public_to=bygri-mail
+
+class SMTPClientTests: XCTestCase {
+    static let allTests = [
+        ("testProvider", testProvider),
+    ]
+
+    let username = "username" // Set here, but don't commit to git!
+    let password = "password"
+    let host = "host"
+    let port = 0
+    let securityLayer: SecurityLayer = .tls(nil)
+
+    func testProvider() throws {
+        if username == "username" && password == "password" && host == "host" && port == 0 {
+            print("Not testing SMTP as no configuration is set")
+            return
+        }
+        let config = Settings.Config([
+            "smtp": [
+                "username": Node(username),
+                "password": Node(password),
+                "host": Node(host),
+                "port": Node(port),
+            ],
+        ])
+        let drop = try makeDroplet(config: config)
+        SMTPClient<TCPClientStream>.setSecurityLayer(.tls(nil))
+        try drop.addProvider(Mail.Provider<SMTPClient<TCPClientStream>>.self)
+
+        let email = SMTP.Email(from: "bygri-mail-from@mailinator.com",
+                          to: "bygri-mail@mailinator.com",
+                          subject: "Email Subject",
+                          body: "Hello Email")
+        let attachment = EmailAttachment(filename: "dummy.data",
+                                         contentType: "dummy/data",
+                                         body: [1,2,3,4,5])
+        email.attachments.append(attachment)
+        try drop.mailer?.send(email)
+    }
+
+}
+
+extension SMTPClientTests {
+    func makeDroplet(config: Settings.Config? = nil) throws -> Droplet {
+        let drop = Droplet(arguments: ["/dummy/path/", "prepare"], config: config)
+        try drop.runCommands()
+        return drop
+    }
+}


### PR DESCRIPTION
Extends Vapor's existing `SMTPClient`, allows it to be used with the `MailClientProtocol` as a more-or-less swappable backend (a bit more config is required in code).