### PR TITLE
Make SendGridError.errors public

### DIFF
--- a/Sources/SendGrid/Models/SendGridError.swift
+++ b/Sources/SendGrid/Models/SendGridError.swift
@@ -1,6 +1,6 @@
 import Vapor
 public struct SendGridError: Error, Content {
-    var errors: [SendGridErrorResponse]?
+    public var errors: [SendGridErrorResponse]?
 }
 
 public struct SendGridErrorResponse: Content {


### PR DESCRIPTION
Defeats the purpose if it's not accessible from outside this package.