### PR TITLE
Change the package name to lowercase.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "SendGrid",
+    name: "sendgrid",
     platforms: [
         .macOS(.v10_15)
     ],


### PR DESCRIPTION
fix an error on Xcode 11.4 + Swift 5.2 + Vapor 4